### PR TITLE
add search_by_id to z3950_connection

### DIFF
--- a/lib/lsp-data/z3950_connection.rb
+++ b/lib/lsp-data/z3950_connection.rb
@@ -25,10 +25,16 @@ module LspData
     end
   end
 
-  ### index is a Bib-1 Use Attribute (see https://www.loc.gov/z3950/agency/defns/bib1.html)
-  ### nil records are included in results array to allow further action if needed
-  def search(index:, identifier:)
+  ### This is a convenience method used to perform a single search by an ID such as OCLC #, ISBN, etc.
+  ### 'index' is the value of the Bib-1 Use Attribute (see https://www.loc.gov/z3950/agency/defns/bib1.html)
+  def search_by_id(index:, identifier:)
     search_string = "@attr 1=#{index} #{identifier}"
+    search(search_string)
+  end
+
+  ### General search method that accepts a raw PQF query (see https://software.indexdata.com/yaz/doc/tools.html#pqf-examples)
+  ### nil records are included in results array to allow further action if needed
+  def search(search_string)
     response = connection.search(search_string)
     response.records.map do |result|
       result.nil? ? result : record_from_result(result)

--- a/spec/z3950_connection_spec.rb
+++ b/spec/z3950_connection_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe LspData::Z3950Connection do
     let(:identifier) { '9781984899422' }
 
     it 'returns a valid record' do
-      record = connection.search(index: index, identifier: identifier).first
+      record = connection.search_by_id(index: index, identifier: identifier).first
       f020 = record.fields('020').map { |field| field['a'] }
       expect(record.class).to eq MARC::Record
       expect(f020).to include identifier


### PR DESCRIPTION
This version of the code modifies the 'search' method to perform any query by accepting a raw PQF string.  The new 'search_by_id' method has the signature of the old 'search' method, accepting an index and identifier and constructing the query string.  The general 'search' method should make it easy to create other such convenience methods for other kinds of searches.