### PR TITLE
figgy object class and address logger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'coveralls_reborn'
 gem 'base64'
 gem 'csv'
 gem 'alexandria-zoom'
+gem 'logger'
 
 group :development, :test do
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,7 @@ GEM
     json (2.8.1)
     language_server-protocol (3.17.0.3)
     library_stdnums (1.6.0)
+    logger (1.7.0)
     marc (1.3.0)
       nokogiri (~> 1.0)
       rexml
@@ -182,6 +183,7 @@ DEPENDENCIES
   faraday (~> 1.0)
   irb
   library_stdnums (~> 1.6)
+  logger
   marc (~> 1.0)
   marc_cleanup!
   marc_match_key!

--- a/lib/lsp-data.rb
+++ b/lib/lsp-data.rb
@@ -29,4 +29,5 @@ require_relative 'lsp-data/api_update_portfolio'
 require_relative 'lsp-data/oit_person_to_alma'
 require_relative 'lsp-data/z3950_connection'
 require_relative 'lsp-data/oclc_record_match'
+require_relative 'lsp-data/figgy_digital_object'
 include LspData

--- a/lib/lsp-data/figgy_digital_object.rb
+++ b/lib/lsp-data/figgy_digital_object.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module LspData
+  ### Transform a hash derived from the Figgy report into an object with the following
+  ###   mandatory features:
+  ###    1. Visibility (princeton, open, reading room, private, on campus) (taken from the visibility label)
+  ###    2. MMS ID (key of the hash)
+  ###    3. IIIF Manifest URL
+  ### If the visibility is open, retrieve the metadata from the manifest and add
+  ###   the following features:
+  ###     1. Label
+  ###     2. ARK
+  ###     3. Thumbnail URL
+  class FiggyDigitalObject
+    attr_reader :mms_id, :visibility, :manifest_url, :conn, :manifest_identifier
+
+    def initialize(manifest_info:, mms_id:, conn:)
+      @visibility = manifest_info['visibility']['label']
+      @manifest_url = manifest_info['iiif_manifest_url']
+      @manifest_identifier ||= identifier_from_manifest_url
+      @mms_id = mms_id
+      @conn = conn
+    end
+
+    def manifest_metadata
+      return @manifest_metadata if defined?(@manifest_metadata)
+
+      all_metadata = manifest
+      return @manifest_metadata = nil if all_metadata.nil?
+
+      body = all_metadata[:body]
+      @manifest_metadata = all_metadata[:status] == 200 ? metadata_from_manifest(body) : nil
+    end
+
+    private
+
+    def metadata_from_manifest(body)
+      collection_data = body['metadata'].find { |object| object['label'] == 'Member Of Collections' }.to_h
+      {
+        ark: body['rendering']['@id'],
+        thumbnail: body['thumbnail']['@id'],
+        label: body['label'],
+        collections: collection_data['value']
+      }
+    end
+
+    def identifier_from_manifest_url
+      manifest_url.gsub(%r{^.*scanned_resources/([^/]+)/.*$}, '\1')
+    end
+
+    def manifest
+      return unless visibility == 'open'
+
+      response = api_call
+      parse_api_response(response)
+    end
+
+    def api_call
+      conn.get do |req|
+        req.url "#{manifest_identifier}/manifest"
+        req.headers['Content-Type'] = 'application/json'
+        req.headers['Accept'] = 'application/json'
+      end
+    end
+  end
+end

--- a/spec/figgy_digital_object_spec.rb
+++ b/spec/figgy_digital_object_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative './../lib/lsp-data'
+require 'spec_helper'
+
+RSpec.describe LspData::FiggyDigitalObject do # rubocop:disable Metrics/BlockLength
+  subject(:figgy_object) do
+    described_class.new(manifest_info: stub_json_fixture(fixture: fixture), mms_id: mms_id, conn: conn)
+  end
+  let(:conn) { LspData.api_conn('https://figgy.princeton.edu/concern/scanned_resources') }
+  let(:mms_id) { '99129146648906421' }
+
+  context 'private visibility item' do
+    let(:fixture) { 'private_figgy_report.json' }
+
+    it 'has IIIF manifest URL, manifest identifier, MMS ID, and visibility with no info from the manifest metadata' do
+      expect(figgy_object.mms_id).to eq mms_id
+      expect(figgy_object.visibility).to eq 'private'
+      expect(figgy_object.manifest_url).to eq 'https://figgy.princeton.edu/concern/scanned_resources/123/manifest'
+      expect(figgy_object.manifest_identifier).to eq '123'
+      expect(figgy_object.manifest_metadata).to be nil
+    end
+  end
+
+  context 'open visibility item' do
+    let(:fixture) { 'open_figgy_report.json' }
+    let(:manifest_fixture) { 'figgy_manifest.json' }
+    let(:thumbnail_url) { 'https://iiif-cloud.princeton.edu/iiif/1/file/default.jpg' }
+    let(:desired_manifest) do
+      { ark: 'http://arks.princeton.edu/ark:/88435/ab01cd39z', label: 'Label',
+        thumbnail: thumbnail_url, collections: ['Collection 1', 'Collection 2'] }
+    end
+
+    it 'has all manifest metadata' do
+      stub_get_manifest_response(manifest_identifer: figgy_object.manifest_identifier, fixture: manifest_fixture)
+      expect(figgy_object.visibility).to eq 'open'
+      expect(figgy_object.manifest_metadata).to eq desired_manifest
+    end
+  end
+end

--- a/spec/fixtures/files/figgy_manifest.json
+++ b/spec/fixtures/files/figgy_manifest.json
@@ -1,0 +1,27 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@type": "sc:Manifest",
+  "@id": "https://figgy.princeton.edu/concern/scanned_resources/123/manifest",
+  "label": "Label",
+  "metadata": [
+    {
+      "label": "Member Of Collections",
+      "value": [
+        "Collection 1",
+        "Collection 2"
+      ]
+    }
+  ],
+  "thumbnail": {
+    "@id": "https://iiif-cloud.princeton.edu/iiif/1/file/default.jpg",
+    "service": {
+      "@context": "http://iiif.io/api/image/2/context.json",
+      "@id": "https://iiif-cloud.princeton.edu/iiif/1/file",
+      "profile": "http://iiif.io/api/image/2/level2.json"
+    }
+  },
+  "rendering": {
+    "@id": "http://arks.princeton.edu/ark:/88435/ab01cd39z",
+    "format": "text/html"
+  }
+}

--- a/spec/fixtures/files/open_figgy_report.json
+++ b/spec/fixtures/files/open_figgy_report.json
@@ -1,0 +1,9 @@
+{
+    "visibility": {
+        "value": "open",
+        "label": "open",
+        "definition": "Open to the world. Anyone can view."
+    },
+    "portion_note": null,
+    "iiif_manifest_url": "https://figgy.princeton.edu/concern/scanned_resources/123/manifest"
+}

--- a/spec/fixtures/files/private_figgy_report.json
+++ b/spec/fixtures/files/private_figgy_report.json
@@ -1,0 +1,9 @@
+{
+    "visibility": {
+        "value": "restricted",
+        "label": "private",
+        "definition": "Only privileged users of this application can view."
+    },
+    "portion_note": null,
+    "iiif_manifest_url": "https://figgy.princeton.edu/concern/scanned_resources/123/manifest"
+}

--- a/spec/support/fixture_helpers.rb
+++ b/spec/support/fixture_helpers.rb
@@ -51,6 +51,21 @@ def stub_get_portfolio_response(mms_id:, portfolio_id:, fixture:)
     .to_return(status: 200, body: data)
 end
 
+def stub_get_manifest_response(manifest_identifer:, fixture:)
+  file = File.open("#{FIXTURE_DIR}/#{fixture}")
+  data = File.read(file)
+  stub_request(:get, "https://figgy.princeton.edu/concern/scanned_resources/123/manifest")
+    .with(
+           headers: {
+                      'Accept'=>'application/json',
+       	              'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+       	              'Content-Type'=>'application/json',
+       	              'User-Agent'=>'Faraday v1.10.4'
+                    }
+         )
+    .to_return(status: 200, body: data)
+end
+
 def stub_put_portfolio_response(mms_id:, portfolio_id:, fixture:, status:)
   body = stub_json_fixture(fixture: fixture)
   url = "https://api-na.exlibrisgroup.com/almaws/v1/bibs/#{mms_id}/portfolios/#{portfolio_id}?apikey=apikey"


### PR DESCRIPTION
Addresses https://github.com/PrincetonUniversityLibrary/alma-config/issues/1854

While the final details of the integration are under discussion, I need some mechanism for loading a representative sample of manifests as digital inventory. Provided that a report of some kind is generated by Figgy for ingest, this class should be adapted easily enough to the final format.