### PR TITLE
add illiad users and article borrowing

### DIFF
--- a/lib/lsp-data/illiad/illiad.rb
+++ b/lib/lsp-data/illiad/illiad.rb
@@ -11,14 +11,22 @@ module LspData
       @conn = tds_client_class.new(credentials)
     end
 
-    def all_borrowing
-      conn.execute(borrowing_query).map { |row| ILLiadBorrowing.new(transaction_info: row) }
+    def all_loan_borrowing
+      conn.execute(loan_borrowing_query).map { |row| ILLiadBorrowing.new(transaction_info: row) }
+    end
+
+    def all_article_borrowing
+      conn.execute(article_borrowing_query).map { |row| ILLiadBorrowing.new(transaction_info: row) }
+    end
+
+    def all_users
+      conn.execute(user_query).map { |row| ILLiadUser.new(transaction_info: row) }
     end
 
     private
 
     # rubocop:disable Metrics/MethodLength
-    def borrowing_query
+    def loan_borrowing_query
       %(
         SELECT
           TransactionNumber,
@@ -41,6 +49,48 @@ module LspData
       ORDER BY TransactionNumber
       )
     end
+
+    def article_borrowing_query
+      %(
+        SELECT
+          TransactionNumber,
+          RequestType,
+          Username,
+          CreationDate,
+          TransactionStatus,
+          TransactionDate,
+          ProcessType,
+          LendingLibrary,
+          ISSN,
+          ESPNumber,
+          ILLNumber,
+          SystemID
+      FROM Transactions
+      WHERE
+          TransactionStatus != 'Cancelled by ILL Staff'
+          AND RequestType = 'Article'
+          AND ProcessType IN ('Borrowing', 'DocDel')
+      ORDER BY TransactionNumber
+      )
+    end
     # rubocop:enable Metrics/MethodLength
+
+    def user_query
+      %(
+        SELECT
+          UserName,
+          LastName,
+          FirstName,
+          SSN,
+          Status,
+          Department,
+          NVTGC,
+          LastChangedDate,
+          Site,
+          ExpirationDate,
+          Number
+        FROM UsersALL
+      )
+    end
   end
 end

--- a/lib/lsp-data/illiad/illiad_borrowing.rb
+++ b/lib/lsp-data/illiad/illiad_borrowing.rb
@@ -15,9 +15,10 @@ module LspData
   ###   ESPNumber (OCLC number, if SystemID = 'OCLC')
   ###   ILLNumber
   ###   SystemID
+  ###   ProcessType
   class ILLiadBorrowing
-    attr_reader :transaction_number, :username, :creation_date, :transaction_status,
-                :transaction_date, :lending_library, :ill_number, :transaction_info, :system_id
+    attr_reader :transaction_number, :username, :creation_date, :transaction_status, :transaction_date,
+                :lending_library, :ill_number, :transaction_info, :system_id, :process_type
 
     def initialize(transaction_info:)
       @transaction_info = transaction_info
@@ -29,6 +30,7 @@ module LspData
       @lending_library = transaction_info['LendingLibrary']
       @system_id = transaction_info['SystemID']
       @ill_number = transaction_info['ILLNumber']
+      @process_type = transaction_info['ProcessType']
     end
 
     def oclc_num

--- a/lib/lsp-data/illiad/illiad_user.rb
+++ b/lib/lsp-data/illiad/illiad_user.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module LspData
+  ### This class transforms information retrieved from the ILLiad SQL Server
+  ###   related to user information.
+  ### Fields to parse:
+  ###   UserName
+  ###   LastName
+  ###   FirstName
+  ###   SSN [patron barcode]
+  ###   Status
+  ###   Department
+  ###   NVTGC
+  ###   LastChangedDate
+  ###   Site
+  ###   ExpirationDate
+  ###   Number [primary identifier]
+  class ILLiadUser
+    attr_reader :username, :last_name, :first_name, :patron_barcode, :status, :department,
+                :nvtgc, :modification_date, :site, :expiration_date, :primary_id
+
+    # rubocop:disable Metrics/MethodLength
+    def initialize(transaction_info:)
+      @username = transaction_info['UserName']
+      @last_name = transaction_info['LastName']
+      @first_name = transaction_info['FirstName']
+      @patron_barcode = transaction_info['SSN']&.gsub(/\s/, ' ')
+      @status = transaction_info['Status']
+      @department = transaction_info['Department']
+      @nvtgc = transaction_info['NVTGC']
+      @modification_date = transaction_info['LastChangedDate'] # Time
+      @site = transaction_info['Site']
+      @expiration_date = transaction_info['ExpirationDate'] # Time
+      @primary_id = transaction_info['Number']
+    end
+    # rubocop:enable Metrics/MethodLength
+  end
+end

--- a/spec/illiad_borrowing_spec.rb
+++ b/spec/illiad_borrowing_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe LspData::ILLiadBorrowing do
       expect(illiad_borrowing.issn).to be_nil
       expect(illiad_borrowing.ill_number).to eq 'NumberOne'
       expect(illiad_borrowing.oclc_num).to eq '1234'
+      expect(illiad_borrowing.process_type).to eq 'Borrowing'
     end
   end
   context 'transaction has ISSN in ISSN field' do

--- a/spec/illiad_spec.rb
+++ b/spec/illiad_spec.rb
@@ -13,23 +13,59 @@ class FakeClient
   end
 
   # rubocop:disable Metrics/MethodLength
-  def execute(_query)
-    [
-      {
-        'TransactionNumber' => 1,
-        'Username' => 'user',
-        'CreationDate' => Time.new(2025, 3, 1, 2, 10, 1, '-05:00'),
-        'TransactionStatus' => 'Request Finished',
-        'TransactionDate' => Time.new(2025, 3, 1, 2, 11, 1, '-05:00'),
-        'LendingLibrary' => 'PASG',
-        'ISSN' => '9789004072725',
-        'ESPNumber' => '1234',
-        'ILLNumber' => 'NumberOne',
-        'SystemID' => 'OCLC',
-        'RequestType' => 'Loan',
-        'ProcessType' => 'Borrowing'
-      }
-    ]
+  def execute(query)
+    case query
+    when /RequestType = 'Loan'/
+      [
+        {
+          'TransactionNumber' => 1,
+          'Username' => 'user',
+          'CreationDate' => Time.new(2025, 3, 1, 2, 10, 1, '-05:00'),
+          'TransactionStatus' => 'Request Finished',
+          'TransactionDate' => Time.new(2025, 3, 1, 2, 11, 1, '-05:00'),
+          'LendingLibrary' => 'PASG',
+          'ISSN' => '9789004072725',
+          'ESPNumber' => '1234',
+          'ILLNumber' => 'NumberOne',
+          'SystemID' => 'OCLC',
+          'RequestType' => 'Loan',
+          'ProcessType' => 'Borrowing'
+        }
+      ]
+    when /RequestType = 'Article'/
+      [
+        {
+          'TransactionNumber' => 2,
+          'Username' => 'user',
+          'CreationDate' => Time.new(2025, 3, 1, 2, 10, 1, '-05:00'),
+          'TransactionStatus' => 'Request Finished',
+          'TransactionDate' => Time.new(2025, 3, 1, 2, 11, 1, '-05:00'),
+          'LendingLibrary' => 'PASG',
+          'ISSN' => '9789004072725',
+          'ESPNumber' => '1234',
+          'ILLNumber' => 'NumberOne',
+          'SystemID' => 'OCLC',
+          'RequestType' => 'Article',
+          'ProcessType' => 'DocDel'
+        }
+      ]
+    when /FROM UsersALL/
+      [
+        {
+          'UserName' => 'ab1234',
+          'LastName' => 'User',
+          'FirstName' => 'Test',
+          'SSN' => '22101123456789',
+          'Status' => 'U - Undergraduate',
+          'Department' => 'Research Computing',
+          'NVTGC' => 'ILL',
+          'LastChangedDate' => Time.new(2025, 3, 1, 2, 11, 1, '-05:00'),
+          'Site' => 'Firestone',
+          'ExpirationDate' => Time.new(2028, 3, 1, 2, 11, 1, '-05:00'),
+          'Number' => '123456789'
+        }
+      ]
+    end
   end
   # rubocop:enable Metrics/MethodLength
 end
@@ -58,8 +94,8 @@ RSpec.describe LspData::ILLiad do
     end
   end
 
-  context 'all borrowing requested' do
-    let(:query) { illiad.send(:borrowing_query) }
+  context 'all loan borrowing requested' do
+    let(:query) { illiad.send(:loan_borrowing_query) }
     let(:response) do
       [
         {
@@ -79,7 +115,56 @@ RSpec.describe LspData::ILLiad do
       ]
     end
     it 'returns ILLiadBorrowing objects' do
-      expect(illiad.all_borrowing.first.transaction_number).to eq(1)
+      expect(illiad.all_loan_borrowing.first.transaction_number).to eq(1)
+    end
+  end
+
+  context 'all article borrowing requested' do
+    let(:query) { illiad.send(:article_borrowing_query) }
+    let(:response) do
+      [
+        {
+          'TransactionNumber' => 2,
+          'Username' => 'user',
+          'CreationDate' => Time.new(2025, 3, 1, 2, 10, 1, '-05:00'),
+          'TransactionStatus' => 'Request Finished',
+          'TransactionDate' => Time.new(2025, 3, 1, 2, 11, 1, '-05:00'),
+          'LendingLibrary' => 'PASG',
+          'ISSN' => '9789004072725',
+          'ESPNumber' => '1234',
+          'ILLNumber' => 'NumberOne',
+          'SystemID' => 'OCLC',
+          'RequestType' => 'Loan',
+          'ProcessType' => 'Borrowing'
+        }
+      ]
+    end
+    it 'returns ILLiadBorrowing objects' do
+      expect(illiad.all_article_borrowing.first.class).to eq ILLiadBorrowing
+    end
+  end
+
+  context 'all users requested' do
+    let(:query) { illiad.send(:user_query) }
+    let(:response) do
+      [
+        {
+          'UserName' => 'ab1234',
+          'LastName' => 'User',
+          'FirstName' => 'Test',
+          'SSN' => '22101123456789',
+          'Status' => 'U - Undergraduate',
+          'Department' => 'Research Computing',
+          'NVTGC' => 'ILL',
+          'LastChangedDate' => Time.new(2025, 3, 1, 2, 11, 1, '-05:00'),
+          'Site' => 'Firestone',
+          'ExpirationDate' => Time.new(2028, 3, 1, 2, 11, 1, '-05:00'),
+          'Number' => '123456789'
+        }
+      ]
+    end
+    it 'returns ILLiadUser objects' do
+      expect(illiad.all_users.first.class).to eq ILLiadUser
     end
   end
 end

--- a/spec/illiad_user_spec.rb
+++ b/spec/illiad_user_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require_relative '../lib/lsp-data'
+require 'spec_helper'
+
+RSpec.describe LspData::ILLiadUser do
+  subject(:illiad_user) do
+    described_class.new(transaction_info: transaction_info)
+  end
+
+  context 'standard user' do
+    let(:transaction_info) do
+      {
+        'UserName' => 'ab1234',
+        'LastName' => 'User',
+        'FirstName' => 'Test',
+        'SSN' => '22101123456789',
+        'Status' => 'U - Undergraduate',
+        'Department' => 'Research Computing',
+        'NVTGC' => 'ILL',
+        'LastChangedDate' => Time.new(2025, 3, 1, 2, 11, 1, '-05:00'),
+        'Site' => 'Firestone',
+        'ExpirationDate' => Time.new(2028, 3, 1, 2, 11, 1, '-05:00'),
+        'Number' => '123456789'
+      }
+    end
+    it 'returns an object with all elements' do
+      expect(illiad_user.username).to eq 'ab1234'
+      expect(illiad_user.last_name).to eq 'User'
+      expect(illiad_user.first_name).to eq 'Test'
+      expect(illiad_user.patron_barcode).to eq '22101123456789'
+      expect(illiad_user.status).to eq 'U - Undergraduate'
+      expect(illiad_user.department).to eq 'Research Computing'
+      expect(illiad_user.nvtgc).to eq 'ILL'
+      expect(illiad_user.modification_date).to eq Time.new(2025, 3, 1, 2, 11, 1, '-05:00')
+      expect(illiad_user.site).to eq 'Firestone'
+      expect(illiad_user.expiration_date).to eq Time.new(2028, 3, 1, 2, 11, 1, '-05:00')
+      expect(illiad_user.primary_id).to eq '123456789'
+    end
+  end
+end

--- a/tasks/illiad_users_no_transactions_seven_years.rb
+++ b/tasks/illiad_users_no_transactions_seven_years.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Want report of all users that have had no requests in over seven years (since 1/1/2019)
+require_relative '../lib/lsp-data'
+require 'csv'
+
+input_dir = ENV.fetch('DATA_INPUT_DIR', nil)
+output_dir = ENV.fetch('DATA_OUTPUT_DIR', nil)
+
+### Get all information on users and requests
+illiad_conn = ILLiad.new
+loans_by_user = illiad_conn.all_loan_borrowing.group_by(&:username)
+articles_by_user = illiad_conn.all_article_borrowing.group_by(&:username)
+all_users = illiad_conn.all_users
+date_cutoff = Time.new(2019, 1, 1, 0, 0, 0, '-05:00')
+
+### Run Alma Analytics query to return all netIDs of users currently in Alma,
+###   with Alma expiry and purge dates
+alma_users = {} # netID is the key
+CSV.open("#{input_dir}/all_alma_users_netids.csv", 'r', encoding: 'bom|utf-8', headers: true).each do |row|
+  alma_users[row['Identifier Value']] = {
+    status: row['Status'],
+    expiry: row['Expiry Date'],
+    purge: row['Purge Date']
+  }
+end
+
+### If there is no loan or article request with a transaction date after 1/1/2019,
+###   report the date of the last loan transaction and last article transaction
+File.open("#{output_dir}/illiad_users_no_transactions_seven_years.tsv", 'w') do |output|
+  output.write("Username\tLast Name\tFirst Name\tPatron Barcode\tStatus\tDepartment\t")
+  output.write("NVTGC\tModification Date\tSite\tExpiration Date\tPrimary Identifier\t")
+  output.puts("Alma Status\tAlma Expiry Date\tAlma Purge Date\tDate of Last Article Request\tDate of Last Loan")
+  all_users.each do |user|
+    loans = loans_by_user[user.username].to_a
+    articles = articles_by_user[user.username].to_a
+    alma_info = alma_users[user.username]
+    alma_expiry = alma_info&.[](:expiry)
+    alma_status = alma_info&.[](:status)
+    alma_purge = alma_info&.[](:purge)
+    if (loans.size + articles.size).zero?
+      output.write("#{user.username}\t#{user.last_name}\t#{user.first_name}\t#{user.patron_barcode}\t")
+      output.write("#{user.status}\t#{user.department}\t#{user.nvtgc}\t#{user.modification_date}\t#{user.site}\t")
+      output.puts("#{user.expiration_date}\t#{user.primary_id}\t#{alma_status}\t#{alma_expiry}\t#{alma_purge}\t\t\t")
+    else
+      last_loan_date = loans.max { |a, b| a.transaction_date <=> b.transaction_date }&.transaction_date
+      last_article_date = articles.max { |a, b| a.transaction_date <=> b.transaction_date }&.transaction_date
+      next if last_loan_date && last_loan_date > date_cutoff
+      next if last_article_date && last_article_date > date_cutoff
+
+      output.write("#{user.username}\t#{user.last_name}\t#{user.first_name}\t#{user.patron_barcode}\t")
+      output.write("#{user.status}\t#{user.department}\t#{user.nvtgc}\t#{user.modification_date}\t#{user.site}\t")
+      output.write("#{user.expiration_date}\t#{user.primary_id}\t")
+      output.puts("#{alma_status}\t#{alma_expiry}\t#{alma_purge}\t#{last_article_date}\t#{last_loan_date}")
+    end
+  end
+end

--- a/tasks/marquand_borrowing.rb
+++ b/tasks/marquand_borrowing.rb
@@ -243,10 +243,10 @@ end
 ###   g. SCSB Owning Institutions
 ###   h. SCSB Customer Codes
 ###   i. SCSB CGDs
-output = File.open("#{output_dir}/marquand_borrowing_report_by_alma_holding.tsv", 'w')
-output.write("MMS ID\tTitle\tHolding ID\tCall Number\tLocation\t")
-output.write("ILLiad Requests\tBorrowDirect Requests\t")
-output.puts("SCSB Requests\tSCSB Owning Institutions\tSCSB Customer Codes\tSCSB CGDs")
+main_output = File.open("#{output_dir}/marquand_borrowing_report_by_alma_holding.tsv", 'w')
+main_output.write("MMS ID\tTitle\tHolding ID\tCall Number\tLocation\t")
+main_output.write("ILLiad Requests\tBorrowDirect Requests\t")
+main_output.puts("SCSB Requests\tSCSB Owning Institutions\tSCSB Customer Codes\tSCSB CGDs")
 goldrush_to_mms_id.each do |key, mms_ids|
   scsb_partners = goldrush_to_partners[key]
   scsb_partners ||= {}
@@ -259,21 +259,21 @@ goldrush_to_mms_id.each do |key, mms_ids|
   mms_ids.each do |mms_id|
     mms_info = bib_info[mms_id]
     mms_info[:holdings].each do |holding|
-      output.write("#{mms_id}\t")
-      output.write("#{mms_info[:title]}\t")
-      output.write("#{holding[:id]}\t")
-      output.write("#{holding[:call_num].full_call_num.strip}\t")
-      output.write("#{holding[:location]}\t")
-      output.write("#{illiad_requests}\t")
-      output.write("#{bd_requests}\t")
-      output.write("#{scsb_requests}\t")
-      output.write("#{scsb_info[:owning_institutions].join(' | ')}\t")
-      output.write("#{scsb_info[:customer_codes].join(' | ')}\t")
-      output.puts(scsb_info[:cgds].join(' | '))
+      main_output.write("#{mms_id}\t")
+      main_output.write("#{mms_info[:title]}\t")
+      main_output.write("#{holding[:id]}\t")
+      main_output.write("#{holding[:call_num].full_call_num.strip}\t")
+      main_output.write("#{holding[:location]}\t")
+      main_output.write("#{illiad_requests}\t")
+      main_output.write("#{bd_requests}\t")
+      main_output.write("#{scsb_requests}\t")
+      main_output.write("#{scsb_info[:owning_institutions].join(' | ')}\t")
+      main_output.write("#{scsb_info[:customer_codes].join(' | ')}\t")
+      main_output.puts(scsb_info[:cgds].join(' | '))
     end
   end
 end
-output.close
+main_output.close
 
 ### A second report was requested to show number of requests per year
 ### Raw data should be the following:
@@ -281,41 +281,32 @@ output.close
 ###   2. Request date [creation date]
 ###   3. Year of request
 ###   4. Type of request
-File.open("#{output_dir}/marquand_borrowing_report_requests_by_date.tsv", 'w') do |output|
-  output.puts("MMS ID\tRequest Date\tYear of Request\tType of Request")
-  goldrush_to_mms_id.each do |key, mms_ids|
-    scsb_partners = goldrush_to_partners[key]
-    scsb_partners ||= {}
-    ill_matches = goldrush_to_transaction_id[key].to_a
-    ill_info = ill_matches.map { |trans_id| all_borrowing.find { |request| request.transaction_number == trans_id } }
-    illiad_requests = ill_info.reject { |request| request.transaction_info['SystemID'] == 'Reshare:princeton' }
-    bd_requests = ill_info.select { |request| request.transaction_info['SystemID'] == 'Reshare:princeton' }
-    scsb_info = info_from_scsb_partners(scsb_partners)
-    scsb_requests = request_count_from_partners(scsb_partners: scsb_partners, requests_per_barcode: requests_per_barcode)
-    mms_ids.each do |mms_id|
-      illiad_requests.each do |request|
-        output.write("#{mms_id}\t")
-        output.write("#{request.creation_date}\t")
-        output.write("#{request.creation_date.year}\t")
-        output.puts("ILLiad")
-      end
-      bd_requests.each do |request|
-        output.write("#{mms_id}\t")
-        output.write("#{request.creation_date}\t")
-        output.write("#{request.creation_date.year}\t")
-        output.puts("BorrowDirect")
-      end
-      scsb_partners.each_value do |bib_hash|
-        bib_hash.values.flatten.each do |item|
-          requests = requests_per_barcode[item[:barcode]].to_a
-          requests.each do |request|
-            output.write("#{mms_id}\t")
-            output.write("#{request[:request_date]}\t")
-            output.write("#{request[:request_date].year}\t")
-            output.puts("SCSB")
-          end
+request_output = File.open("#{output_dir}/marquand_borrowing_report_requests_by_date.tsv", 'w')
+request_output.puts("MMS ID\tRequest Date\tYear of Request\tType of Request")
+goldrush_to_mms_id.each do |key, mms_ids|
+  scsb_partners = goldrush_to_partners[key]
+  scsb_partners ||= {}
+  ill_matches = goldrush_to_transaction_id[key].to_a
+  ill_info = ill_matches.map { |trans_id| all_borrowing.find { |request| request.transaction_number == trans_id } }
+  illiad_requests = ill_info.reject { |request| request.transaction_info['SystemID'] == 'Reshare:princeton' }
+  bd_requests = ill_info.select { |request| request.transaction_info['SystemID'] == 'Reshare:princeton' }
+  mms_ids.each do |mms_id|
+    illiad_requests.each do |request|
+      request_output.write("#{mms_id}\t#{request.creation_date}\t")
+      request_output.puts("#{request.creation_date.year}\tILLiad")
+    end
+    bd_requests.each do |request|
+      request_output.write("#{mms_id}\t#{request.creation_date}\t")
+      request_output.puts("#{request.creation_date.year}\tBorrowDirect")
+    end
+    scsb_partners.each_value do |bib_hash|
+      bib_hash.values.flatten.each do |item|
+        requests_per_barcode[item[:barcode]].to_a.each do |request|
+          request_output.write("#{mms_id}\t#{request[:request_date]}\t")
+          request_output.puts("#{request[:request_date].year}\tSCSB")
         end
       end
     end
   end
 end
+request_output.close


### PR DESCRIPTION
Addresses #182.

Because I added a new query for article borrowing, I renamed the original borrowing query.

In addition, I had to adjust the Marquand borrowing report in light of the change method name.